### PR TITLE
#167160022 Agents can update property adverts [CRUD]

### DIFF
--- a/Server/Schemas/property_schema.js
+++ b/Server/Schemas/property_schema.js
@@ -6,7 +6,7 @@ const schema = Joi.object().keys({
     purpose: Joi.string().trim().max(8).required(),
     city: Joi.string().trim().max(20).required(),
     address: Joi.string().trim().min(10).max(50).required(),
-    type: Joi.string().trim().max(15).min(8).required(),
+    type: Joi.string().trim().max(25).min(8).required(),
     title: Joi.string().trim().min(10).max(50).required(),
     description: Joi.string().trim().min(10).max(1000).required(),
     created_on: Joi.string().required(),

--- a/Server/helpers/verify_property.js
+++ b/Server/helpers/verify_property.js
@@ -1,15 +1,19 @@
 /* eslint-disable no-tabs */
 /* eslint-disable linebreak-style */
 import jwt from 'jsonwebtoken';
-import properties from '../db/properties';
-import validate from './inputValidation';
-import generateId from './generateId';
+
 
 let ownerId;
 
 const day = new Date();
 
 const verifyProperty = (req, res, next) => {
+	if(!req.file) {
+		return res.status(415).json({
+		  status: 'error',
+		  error: 'You must attach a valid image'
+		})
+	  }
 	const property = {
 		owner: ownerId,
 		status: req.body.status,


### PR DESCRIPTION
#### What does this PR do?
Create endpoint for user signup
#### Description of Task to be completed?

- Create endpoint for Agents can update property advert

- Agents should be able to update any property field  - refer to the image below for entry specifications


#### How should this be manually tested?

- clone to local repo

- using postman, visit localhost:5000/api/v1/property/id

- enter details as shown in the screenshot below

- Make a patch request

#### What are the relevant pivotal tracker stories?
#167160022
![schema](https://user-images.githubusercontent.com/47578865/61336911-23407e00-a82b-11e9-9dbc-ce1cd9437bb8.png)